### PR TITLE
Fix bug with Asia/Hebron timezone

### DIFF
--- a/zmanim_api/utils.py
+++ b/zmanim_api/utils.py
@@ -7,6 +7,9 @@ def get_tz(lat: float, lng: float) -> str:
     """ Calculates timezone from coordinates """
     tf = TimezoneFinder()
     tz = tf.timezone_at(lng=lng, lat=lat)
+
+    if tz == 'Asia/Hebron':
+        tz = 'Asia/Jerusalem'
     return tz
 
 


### PR DESCRIPTION
Looks like Asia/Hebron timezone related to Palestine in some of databases, and users with this timezone have no winter time offset.